### PR TITLE
fix build error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git pull
           git add .
           git commit --allow-empty -m ":robot: build automatically"
           git push


### PR DESCRIPTION
## History (How found this error?)
1. I used old GH_TOKEN, and pull upstream code
2. Run build.. but failed. because old GH_TOKEN 
3. Update GH_TOKEN. but failed again. This error looks like the picture below 
![image](https://user-images.githubusercontent.com/29722636/125219824-7f4a1a00-e300-11eb-87b3-0011255af791.png)
4. I tried add git pull in build.yml > run
5. Success!

Thank you! :)