### PR TITLE
Update node version & Remove useless actions/checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
       matrix:
         node_version: [14]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node_version }}
       - name: build
@@ -30,7 +30,7 @@ jobs:
           git commit --allow-empty -m ":robot: build automatically"
           git push
       - name: repository dispatch
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GH_TOKEN }}
           event-type: build-event

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -8,7 +8,6 @@ jobs:
   update-gist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Update gist
         uses: maxam2017/productive-box@master
         env:

--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ branding:
   icon: "activity"
   color: "blue"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
## Commit Description

#### 1. Update actions version - 8cd9107
- To support Node 16
  - [actions/checkout](https://github.com/actions/checkout/releases/tag/v3.0.0)
  - [actions/setup-node](https://github.com/actions/setup-node/releases/tag/v3.0.0)
  - [peter-evans/repository-dispatch](https://github.com/peter-evans/repository-dispatch/releases/tag/v2.0.0)

#### 2. Update node version from 12 to 16 - c05f308
- [Node 12 is deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

#### 3. Remove useless actions/checkout - 8858edd
- Remove useless step (actions/checkout)

## Test
- https://github.com/ckyeon/test-productive-box
- https://github.com/ckyeon/test-productive-box/actions
- https://gist.github.com/ckyeon/e02e658560b14dd3d0310c2ac103f32d