### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
With following readme setup guides. i meet github actions permission denying messages.

``` test
remote: Permission to --- denied to github-actions[bot].
fatal: unable to access ---: The requested URL returned error: 403
Error: Process completed with exit code 128.
```

Users can resolve this issue to configure workflow permission settings, but also it can be resolved by add permission to workflow. this solution is referenced by [stackoverflow answers](https://stackoverflow.com/questions/73687176/permission-denied-to-github-actionsbot-the-requested-url-returned-error-403)