### PR TITLE
👷 use latest major version for actions/checkout and actions/setup-node + allow workflow to be run manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         node_version: [16]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node_version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
       - name: build

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -4,6 +4,8 @@ on:
     types: [build-event]
   schedule:
     - cron: "0 0 * * *"
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 jobs:
   update-gist:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR fixes issue #105:
- Use latest major version of [actions/setup-node](https://github.com/actions/setup-node) and [actions/checkout](https://github.com/actions/checkout) for GitHub Actions.  
- Allow workflow to be run manually.