### PR TITLE
Make `GIST_ID` as a secret

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -14,5 +14,5 @@ jobs:
         uses: maxam2017/productive-box@master
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GIST_ID: 9842e074b8ee46aef76fd0d493bae0ed
+          GIST_ID: ${{ secrets.GIST_ID }}
           TIMEZONE: Asia/Taipei

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 
 ---
 
-> This project is inspired by an awesome pinned-gist project.<br/>Find more in https://github.com/matchai/awesome-pinned-gists
+> This project is inspired by an awesome pinned-gist project.<br/>
+> Find more in https://github.com/matchai/awesome-pinned-gists
 
 ## Overview
 This project uses GitHub graphQL API to get the commit histories and write into the gist by [rest.js](https://github.com/octokit/rest.js#readme)
@@ -29,21 +30,20 @@ This project uses GitHub graphQL API to get the commit histories and write into 
 ## Setup
 
 ### Prep work
+
 1. Create a new public GitHub Gist (https://gist.github.com/)
 1. Create a token with the `gist` and `repo` scope and copy it. (https://github.com/settings/tokens/new)
    > enable `repo` scope seems **DANGEROUS**<br/>
-   > but this GitHub Action only accesses your commit timestamp in repository you contributed.
+   > but this GitHub Action only accesses your commit timestamp in the repositories you contributed.
 
 ### Project setup
 
 1. Fork this repo
 1. Open the "Actions" tab of your fork and click the "enable" button
-1. Edit the [environment variable](https://github.com/maxam2017/productive-box/blob/master/.github/workflows/schedule.yml#L17-L18) in `.github/workflows/schedule.yml`:
-
-   - **GIST_ID:** The ID portion from your gist url: `https://gist.github.com/maxam2017/`**`9842e074b8ee46aef76fd0d493bae0ed`**.
-   - **TIMEZONE:** The timezone of your location, eg. `Asia/Taipei` for Taiwan, `America/New_York` for America in New York, etc.
-
-1. Go to the repo **Settings > Secrets**
-1. Add the following environment variables:
+1. Go to the repo **Settings > Secrets**, add the following environment variables:
    - **GH_TOKEN:** The GitHub token generated above.
+   - **GIST_ID:** The ID portion from your gist URL, e.g. `https://gist.github.com/maxam2017/`**`9842e074b8ee46aef76fd0d493bae0ed`**.
+1. (Optional) Edit the [environment variable](https://github.com/maxam2017/productive-box/blob/master/.github/workflows/schedule.yml#L18)
+   in `.github/workflows/schedule.yml`:
+   - **TIMEZONE:** The timezone of your location, e.g. `Asia/Taipei` for Taiwan, `America/New_York` for America in New York, etc.
 1. [Pin the newly created Gist](https://help.github.com/en/github/setting-up-and-managing-your-github-profile/pinning-items-to-your-profile)


### PR DESCRIPTION
Users can write `GIST_ID` in secrets to avoid further modification to files and related commits, which helps for future upstream merges.